### PR TITLE
Refactor tap.parser.Parser.parse_* into parse() and helpers.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,8 @@ Contributors
 ------------
 
 * Chris Clarke
-* Matt Layman
 * Marc Abramowitz
 * Mark E. Hamilton
+* Matt Layman
+* Michael F. Lamb (http://datagrok.org)
 * Nicolas Caniart

--- a/tap/parser.py
+++ b/tap/parser.py
@@ -2,6 +2,7 @@
 
 import re
 import sys
+from io import StringIO
 
 from tap.directive import Directive
 from tap.i18n import _
@@ -41,20 +42,41 @@ class Parser(object):
 
     TAP_MINIMUM_DECLARED_VERSION = 13
 
-    def parse_file(self, filename):
-        """Parse a TAP file and determine what each line in the file is.
+    def parse(self, fh):
+        """Generate tap.line.Line objects, given a file-like object `fh`.
 
-        This is a generator method that will yield each parsed line. The
-        filename is assumed to exist.
+        `fh` may be any object that implements both the iterator and
+        context management protocol (i.e. it can be used in both a
+        "with" statement and a "for...in" statement.)
+
+        Trailing whitespace and newline characters will be automatically
+        stripped from the input lines.
         """
-        with open(filename, 'r') as tap_file:
-            for line in tap_file:
+        if isinstance(fh, basestring):
+            raise TypeError("'fh' should be a file-like object.")
+        with fh:
+            for line in fh:
                 yield self.parse_line(line.rstrip())
 
+    def parse_text(self, text):
+        """Parse a string containing one or more lines of TAP output."""
+        return self.parse(StringIO(text))
+
+    def parse_file(self, filename):
+        """Parse a TAP file to an iterable of tap.line.Line objects.
+
+        This is a generator method that will yield an object for each
+        parsed line. The file given by `filename` is assumed to exist.
+        """
+        return self.parse(open(filename, 'r'))
+
     def parse_stdin(self):
-        """Parse a TAP stream from STDIN."""
-        for line in sys.stdin:
-            yield self.parse_line(line.rstrip())
+        """Parse a TAP stream from standard input.
+
+        Note: this has the side effect of closing the standard input
+        filehandle after parsing.
+        """
+        return self.parse(sys.stdin)
 
     def parse_line(self, text):
         """Parse a line into whatever TAP category it belongs."""

--- a/tap/parser.py
+++ b/tap/parser.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2016, Matt Layman
 
+from io import StringIO
 import re
 import sys
-from io import StringIO
 
 from tap.directive import Directive
 from tap.i18n import _

--- a/tap/parser.py
+++ b/tap/parser.py
@@ -52,8 +52,6 @@ class Parser(object):
         Trailing whitespace and newline characters will be automatically
         stripped from the input lines.
         """
-        if isinstance(fh, basestring):
-            raise TypeError("'fh' should be a file-like object.")
         with fh:
             for line in fh:
                 yield self.parse_line(line.rstrip())

--- a/tap/parser.py
+++ b/tap/parser.py
@@ -42,24 +42,6 @@ class Parser(object):
 
     TAP_MINIMUM_DECLARED_VERSION = 13
 
-    def parse(self, fh):
-        """Generate tap.line.Line objects, given a file-like object `fh`.
-
-        `fh` may be any object that implements both the iterator and
-        context management protocol (i.e. it can be used in both a
-        "with" statement and a "for...in" statement.)
-
-        Trailing whitespace and newline characters will be automatically
-        stripped from the input lines.
-        """
-        with fh:
-            for line in fh:
-                yield self.parse_line(line.rstrip())
-
-    def parse_text(self, text):
-        """Parse a string containing one or more lines of TAP output."""
-        return self.parse(StringIO(text))
-
     def parse_file(self, filename):
         """Parse a TAP file to an iterable of tap.line.Line objects.
 
@@ -75,6 +57,24 @@ class Parser(object):
         filehandle after parsing.
         """
         return self.parse(sys.stdin)
+
+    def parse_text(self, text):
+        """Parse a string containing one or more lines of TAP output."""
+        return self.parse(StringIO(text))
+
+    def parse(self, fh):
+        """Generate tap.line.Line objects, given a file-like object `fh`.
+
+        `fh` may be any object that implements both the iterator and
+        context management protocol (i.e. it can be used in both a
+        "with" statement and a "for...in" statement.)
+
+        Trailing whitespace and newline characters will be automatically
+        stripped from the input lines.
+        """
+        with fh:
+            for line in fh:
+                yield self.parse_line(line.rstrip())
 
     def parse_line(self, text):
         """Parse a line into whatever TAP category it belongs."""

--- a/tap/tests/test_parser.py
+++ b/tap/tests/test_parser.py
@@ -168,13 +168,13 @@ class TestParser(unittest.TestCase):
 
     @mock.patch('tap.parser.sys')
     def test_parses_stdin(self, mock_sys):
-        def stdin_data():
-            yield '1..2\n'
-            yield 'ok 1 A passing test\n'
-            yield 'not ok 2 A failing test\n'
-        mock_stdin = mock.PropertyMock()
-        mock_stdin.side_effect = stdin_data
-        type(mock_sys).stdin = mock_stdin
+        mock_sys.stdin.__iter__.return_value = iter([
+            '1..2\n',
+            'ok 1 A passing test\n',
+            'not ok 2 A failing test\n',
+            ])
+        mock_sys.stdin.__enter__.return_value = None
+        mock_sys.stdin.__exit__.return_value = None
         parser = Parser()
         lines = []
 

--- a/tap/tests/test_parser.py
+++ b/tap/tests/test_parser.py
@@ -145,6 +145,24 @@ class TestParser(unittest.TestCase):
 
         self.assertEqual('unknown', line.category)
 
+    def test_parses_text(self):
+        sample = inspect.cleandoc(
+            u"""1..2
+            ok 1 A passing test
+            not ok 2 A failing test""")
+        parser = Parser()
+        lines = []
+
+        for line in parser.parse_text(sample):
+            lines.append(line)
+
+        self.assertEqual(3, len(lines))
+        self.assertEqual('plan', lines[0].category)
+        self.assertEqual('test', lines[1].category)
+        self.assertTrue(lines[1].ok)
+        self.assertEqual('test', lines[2].category)
+        self.assertFalse(lines[2].ok)
+
     def test_parses_file(self):
         sample = inspect.cleandoc(
             """1..2

--- a/tap/tests/test_parser.py
+++ b/tap/tests/test_parser.py
@@ -190,7 +190,7 @@ class TestParser(unittest.TestCase):
             '1..2\n',
             'ok 1 A passing test\n',
             'not ok 2 A failing test\n',
-            ])
+        ])
         mock_sys.stdin.__enter__.return_value = None
         mock_sys.stdin.__exit__.return_value = None
         parser = Parser()


### PR DESCRIPTION
I wanted to use tap.parser.Parser to parse a blob of TAP output stored in a single string with embedded newlines, but found no convenient method to do so. parse_file() requires a filename rather than a file-like object. Attempting to add a parse_text() method that performed a .splitlines() felt like I was duplicating code.

So, I attempted to factor the common loop and cleanup logic out to a general purpose parse() method, and then replace the other parse_* methods with simple calls to parse().

I updated the existing unit test to better simulate sys.stdin's behavior in a context manager, and added a new unit test for my parse_text() helper.

A future useful helper might be a parse_lines() which accepts an iterable of lines that, having no associated file object, need not be closed after parsing. It could wrap it in a no-op context manager before passing it to parse().