### PR TITLE
Ignore the tests directory.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+ - "tap/tests"


### PR DESCRIPTION
Codecov is needlessly including the `tests` directory in the coverage report.

Fixes #64 