### PR TITLE
Remove control characters from internal representation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       language: generic
       env: TOX_ENV=py27
       before_install:
-        - brew install python3
+        - brew upgrade python
         - python3 -m venv venv
         - source venv/bin/activate
     - os: linux

--- a/tap/directive.py
+++ b/tap/directive.py
@@ -61,3 +61,6 @@ class Directive(object):
     def reason(self):
         """Get the reason for the directive."""
         return self._reason
+
+    def __str__(self):
+        return '# {}'.format(self.text)

--- a/tap/directive.py
+++ b/tap/directive.py
@@ -61,6 +61,3 @@ class Directive(object):
     def reason(self):
         """Get the reason for the directive."""
         return self._reason
-
-    # def __str__(self):
-    #     return '# {}'.format(self.text)

--- a/tap/directive.py
+++ b/tap/directive.py
@@ -22,7 +22,7 @@ class Directive(object):
 
         The text is assumed to be everything after a '#\s*' on a result line.
         """
-        self._text = text
+        self._text = text.lstrip('# ')
         self._skip = False
         self._todo = False
         self._reason = None

--- a/tap/directive.py
+++ b/tap/directive.py
@@ -22,7 +22,7 @@ class Directive(object):
 
         The text is assumed to be everything after a '#\s*' on a result line.
         """
-        self._text = text.lstrip('# ')
+        self._text = text
         self._skip = False
         self._todo = False
         self._reason = None
@@ -62,5 +62,5 @@ class Directive(object):
         """Get the reason for the directive."""
         return self._reason
 
-    def __str__(self):
-        return '# {}'.format(self.text)
+    # def __str__(self):
+    #     return '# {}'.format(self.text)

--- a/tap/line.py
+++ b/tap/line.py
@@ -23,7 +23,7 @@ class Result(Line):
         else:
             # The number may be an empty string so explicitly set to None.
             self._number = None
-        self._description = description
+        self._description = description.lstrip('- ')
         self.directive = directive
         self.diagnostics = diagnostics
 
@@ -116,7 +116,7 @@ class Diagnostic(Line):
     """A diagnostic line (i.e. anything starting with a hash)."""
 
     def __init__(self, text):
-        self._text = text
+        self._text = text.lstrip('# ')
 
     @property
     def category(self):

--- a/tap/line.py
+++ b/tap/line.py
@@ -128,9 +128,6 @@ class Diagnostic(Line):
         """Get the text."""
         return self._text
 
-    def __str__(self):
-        return self._text
-
 
 class Bail(Line):
     """A bail out line (i.e. anything starting with 'Bail out!')."""

--- a/tap/line.py
+++ b/tap/line.py
@@ -128,6 +128,9 @@ class Diagnostic(Line):
         """Get the text."""
         return self._text
 
+    def __str__(self):
+        return '# {}'.format(self.text)
+
 
 class Bail(Line):
     """A bail out line (i.e. anything starting with 'Bail out!')."""

--- a/tap/line.py
+++ b/tap/line.py
@@ -23,7 +23,7 @@ class Result(Line):
         else:
             # The number may be an empty string so explicitly set to None.
             self._number = None
-        self._description = description.lstrip('- ')
+        self._description = description
         self.directive = directive
         self.diagnostics = diagnostics
 
@@ -79,7 +79,7 @@ class Result(Line):
         diagnostics = ''
         if self.diagnostics is not None:
             diagnostics = '\n' + self.diagnostics.rstrip()
-        return "{0}ok {1} - {2}{3}{4}".format(
+        return "{0}ok {1} {2}{3}{4}".format(
             is_not, self.number, self.description, directive, diagnostics)
 
 
@@ -116,7 +116,7 @@ class Diagnostic(Line):
     """A diagnostic line (i.e. anything starting with a hash)."""
 
     def __init__(self, text):
-        self._text = text.lstrip('# ')
+        self._text = text
 
     @property
     def category(self):
@@ -129,7 +129,7 @@ class Diagnostic(Line):
         return self._text
 
     def __str__(self):
-        return '# {}'.format(self.text)
+        return self._text
 
 
 class Bail(Line):

--- a/tap/tests/test_line.py
+++ b/tap/tests/test_line.py
@@ -29,20 +29,20 @@ class TestResult(unittest.TestCase):
     def test_str_ok(self):
         result = Result(True, 42, 'passing')
         self.assertEqual(
-            'ok 42 - passing', str(result))
+            'ok 42 passing', str(result))
 
     def test_str_not_ok(self):
         result = Result(False, 43, 'failing')
         self.assertEqual(
-            'not ok 43 - failing', str(result))
+            'not ok 43 failing', str(result))
 
     def test_str_directive(self):
         directive = Directive('SKIP a reason')
         result = Result(True, 44, 'passing', directive)
         self.assertEqual(
-            'ok 44 - passing # SKIP a reason', str(result))
+            'ok 44 passing # SKIP a reason', str(result))
 
     def test_str_diagnostics(self):
         result = Result(False, 43, 'failing', diagnostics='# more info')
         self.assertEqual(
-            'not ok 43 - failing\n# more info', str(result))
+            'not ok 43 failing\n# more info', str(result))

--- a/tap/tests/test_parser.py
+++ b/tap/tests/test_parser.py
@@ -80,8 +80,9 @@ class TestParser(unittest.TestCase):
     def test_finds_directive(self):
         """The parser extracts a directive"""
         parser = Parser()
+        test_line = 'not ok - This line fails # TODO not implemented'
 
-        line = parser.parse_line('not ok - This line fails # TODO not implemented')
+        line = parser.parse_line(test_line)
         directive = line.directive
 
         self.assertEqual('test', line.category)

--- a/tap/tests/test_parser.py
+++ b/tap/tests/test_parser.py
@@ -92,7 +92,8 @@ class TestParser(unittest.TestCase):
         line = parser.parse_line(text)
 
         self.assertEqual('diagnostic', line.category)
-        self.assertEqual(text, line.text)
+        self.assertEqual(text.lstrip('# '), line.text)
+        self.assertEqual(text, str(line))
 
     def test_bail_out_line(self):
         """The parser extracts a bail out line."""

--- a/tap/tests/test_parser.py
+++ b/tap/tests/test_parser.py
@@ -75,6 +75,20 @@ class TestParser(unittest.TestCase):
         self.assertEqual('test', line.category)
         self.assertFalse(line.ok)
         self.assertTrue(line.number is None)
+        self.assertEqual('', line.directive.text)
+
+    def test_finds_directive(self):
+        """The parser extracts a directive"""
+        parser = Parser()
+
+        line = parser.parse_line('not ok - This line fails # TODO not implemented')
+        directive = line.directive
+
+        self.assertEqual('test', line.category)
+        self.assertEqual('TODO not implemented', directive.text)
+        self.assertFalse(directive.skip)
+        self.assertTrue(directive.todo)
+        self.assertEqual('not implemented', directive.reason)
 
     def test_unrecognizable_line(self):
         """The parser returns an unrecognizable line."""
@@ -92,8 +106,7 @@ class TestParser(unittest.TestCase):
         line = parser.parse_line(text)
 
         self.assertEqual('diagnostic', line.category)
-        self.assertEqual(text.lstrip('# '), line.text)
-        self.assertEqual(text, str(line))
+        self.assertEqual(text, line.text)
 
     def test_bail_out_line(self):
         """The parser extracts a bail out line."""

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -103,9 +103,9 @@ class TestTracker(TestCase):
             report = f.read()
         expected = inspect.cleandoc(
             """{header_1}
-            ok 1 - YESSS!
+            ok 1 YESSS!
             {header_2}
-            ok 2 - GOAAL!
+            ok 2 GOAAL!
             1..2
             """.format(
                 header_1=self._make_header('FakeTestCase'),
@@ -129,9 +129,9 @@ class TestTracker(TestCase):
 
         expected = inspect.cleandoc(
             """{header_1}
-            ok 1 - YESSS!
+            ok 1 YESSS!
             {header_2}
-            ok 2 - Sure.
+            ok 2 Sure.
             """.format(
                 header_1=self._make_header('FakeTestCase'),
                 header_2=self._make_header('AnotherTestCase')))
@@ -145,7 +145,7 @@ class TestTracker(TestCase):
 
         expected = inspect.cleandoc(
             """{header}
-            not ok 1 - YESSS!
+            not ok 1 YESSS!
             """.format(
                 header=self._make_header('FakeTestCase')))
         self.assertEqual(stream.getvalue().strip(), expected)
@@ -158,7 +158,7 @@ class TestTracker(TestCase):
 
         expected = inspect.cleandoc(
             """{header}
-            ok 1 - YESSS! # SKIP a reason
+            ok 1 YESSS! # SKIP a reason
             """.format(
                 header=self._make_header('FakeTestCase')))
         self.assertEqual(stream.getvalue().strip(), expected)
@@ -215,5 +215,5 @@ class TestTracker(TestCase):
         tracker.add_skip('FakeTestCase', 'YESSS!', 'a reason')
 
         expected = inspect.cleandoc(
-            """ok 1 - YESSS! # SKIP a reason""")
+            """ok 1 YESSS! # SKIP a reason""")
         self.assertEqual(stream.getvalue().strip(), expected)


### PR DESCRIPTION
While the control characters are used for splitting TAP output, they are not needed once we have split the output. They can be added as needed when converting to a string. 