### PR TITLE
Pick up subtests

### DIFF
--- a/tap/runner.py
+++ b/tap/runner.py
@@ -36,6 +36,17 @@ class TAPTestResult(TextTestResult):
             self._cls_name(test), self._description(test),
             diagnostics=diagnostics)
 
+    def addSubTest(self, test, subtest, err):
+        super(TAPTestResult, self).addSubTest(test, subtest, err)
+        if err is not None:
+            diagnostics = formatter.format_exception(err)
+            self.tracker.add_not_ok(
+                self._cls_name(test), self._description(subtest),
+                diagnostics=diagnostics)
+        else:
+            self.tracker.add_ok(
+                self._cls_name(test), self._description(subtest))
+
     def addSuccess(self, test):
         super(TAPTestResult, self).addSuccess(test)
         self.tracker.add_ok(self._cls_name(test), self._description(test))


### PR DESCRIPTION
Fix for issue #71.

Subtest executions are recorded by the TextTestRunner using the addSubTest function. This pull request add an override on addSubTest in order to have the subtests added to the tap file. 

The tap file format does include a representation of subtests, e.g. by indention and separate numberings and plans, but that is not reflected in the current patch. To fully comply with that would require a much bigger patch to tappy and is beyond scope of my needs for a patch.

With this patch, subtests will appear in the tap file as if they were regular tests ("non-subtests"). This is most likely good enough for most use cases, and in any case it's better than to not have them in the tap file at all.