### PR TITLE
expectedFailure should be treated as a TODO.

### DIFF
--- a/tap/runner.py
+++ b/tap/runner.py
@@ -50,12 +50,12 @@ class TAPTestResult(TextTestResult):
         diagnostics = formatter.format_exception(err)
         self.tracker.add_not_ok(
             self._cls_name(test), self._description(test),
-            _('(expected failure)'), diagnostics=diagnostics)
+            'TODO {}'.format(_('(expected failure)')), diagnostics=diagnostics)
 
     def addUnexpectedSuccess(self, test):
         super(TAPTestResult, self).addUnexpectedSuccess(test)
         self.tracker.add_ok(self._cls_name(test), self._description(test),
-                            _('(unexpected success)'))
+                            'TODO {}'.format(_('(unexpected success)')))
 
     def _cls_name(self, test):
         return test.__class__.__name__

--- a/tap/tests/test_result.py
+++ b/tap/tests/test_result.py
@@ -62,11 +62,13 @@ class TestTAPTestResult(TestCase):
         result.addExpectedFailure(FakeTestCase(), exc)
         line = result.tracker._test_cases['FakeTestCase'][0]
         self.assertFalse(line.ok)
-        self.assertEqual(line.directive.text, _('(expected failure)'))
+        self.assertEqual(
+            line.directive.text, 'TODO {}'.format(_('(expected failure)')))
 
     def test_adds_unexpected_success(self):
         result = self._make_one()
         result.addUnexpectedSuccess(FakeTestCase())
         line = result.tracker._test_cases['FakeTestCase'][0]
         self.assertTrue(line.ok)
-        self.assertEqual(line.directive.text, _('(unexpected success)'))
+        self.assertEqual(
+            line.directive.text, 'TODO {}'.format(_('(unexpected success)')))


### PR DESCRIPTION
This aligns better with the specification.

> These tests represent a feature to be implemented or a bug to be fixed
and act as something of an executable “things to do” list. They are not
expected to succeed.

Fixes #74