### PR TITLE
Add an optional method to install TAP version 13 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ you only need to install `nose-tap`.
 $ pip install nose-tap
 ```
 
+TAP version 13 brings support
+for [YAML blocks](http://testanything.org/tap-version-13-specification.html#yaml-blocks)
+associated with test results.
+To work with version 13, install the optional dependencies.
+Learn more about YAML support
+in the [TAP version 13](http://tappy.readthedocs.io/en/latest/consumers.html#tap-version-13) section.
+
+```bash
+$ pip install tap.py[yaml]
+```
+
 Motivation
 ----------
 

--- a/docs/consumers.rst
+++ b/docs/consumers.rst
@@ -112,10 +112,12 @@ The API specifics are listed below.
 .. autoclass:: tap.parser.Parser
    :members:
 
+.. _tap-version-13:
+
 TAP version 13
 ~~~~~~~~~~~~~~
 
-The specification for version 13 adds support for `yaml blocks <https://testanything.org/tap-version-13-specification.html#yaml-blocks>`_
+The specification for TAP version 13 adds support for `yaml blocks <https://testanything.org/tap-version-13-specification.html#yaml-blocks>`_
 to provide additional information about the preceding test. In order to consume
 yaml blocks, ``tappy`` requires `pyyaml <https://pypi.org/project/PyYAML/>`_ and
 `more-itertools <https://pypi.org/project/more-itertools/>`_ to be installed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,16 @@ It is continuously tested on Linux, OS X, and Windows.
 
    $ pip install tap.py
 
+TAP version 13 brings support for YAML blocks
+for `YAML blocks <http://testanything.org/tap-version-13-specification.html#yaml-blocks>`_
+associated with test results.
+To work with version 13, install the optional dependencies.
+Learn more about YAML support in the :ref:`tap-version-13` section.
+
+.. code-block:: console
+
+   $ pip install tap.py[yaml]
+
 Documentation
 -------------
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,9 +4,10 @@ Releases
 Version 2.3, To Be Released
 ---------------------------
 
-* Make tappy version 13 compliant by adding
-  support for parsing yaml blocks.
-* `unittest.expectedFailure` now uses a TODO directive to better align
+* Add optional method to install tappy for YAML support
+  with ``pip install tap.py[yaml]``.
+* Make tappy version 13 compliant by adding support for parsing YAML blocks.
+* ``unittest.expectedFailure`` now uses a TODO directive to better align
   with the specification.
 
 Version 2.2, Released January 7, 2018

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,12 @@ if __name__ == '__main__':
         zip_safe=False,
         platforms='any',
         install_requires=[],
+        extras_require={
+            'yaml': [
+                'more-itertools',
+                'PyYAML',
+            ],
+        },
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Environment :: Console',


### PR DESCRIPTION
This branch uses the `extras_require` option to make it possible to quickly install TAP version 13 support. I chose the name `yaml` because I didn't want to tie to version 13 specifically as future versions will support YAML.