### PR TITLE
write the plan line up front in streaming mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Contributors
 * Marc Abramowitz
 * Mark E. Hamilton
 * Matt Layman
+* meejah (https://meejah.ca)
 * Michael F. Lamb (http://datagrok.org)
 * Nicolas Caniart
 * Richard Bosworth

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,13 @@
 Releases
 ========
 
+Version 2.5, In Development
+---------------------------
+
+* Add `set_plan` to `Tracker` which allows producing the `1..N` line
+  before any tests.
+
+
 Version 2.4, Released May 29, 2018
 ----------------------------------
 

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -232,7 +232,7 @@ class TestTracker(TestCase):
     @mock.patch('tap.tracker.ENABLE_VERSION_13', False)
     def test_write_plan_immediate_streaming(self):
         stream = StringIO()
-        tracker = Tracker(streaming=True, stream=stream, plan=123)
+        Tracker(streaming=True, stream=stream, plan=123)
         self.assertEqual(stream.getvalue(), '1..123\n')
 
     @mock.patch('tap.tracker.ENABLE_VERSION_13', False)

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -230,7 +230,7 @@ class TestTracker(TestCase):
         self.assertEqual(stream.getvalue(), '1..123\n')
 
     @mock.patch('tap.tracker.ENABLE_VERSION_13', False)
-    def test_write_plan_first_file(self):
+    def test_write_plan_first_combined(self):
         stream = StringIO()
         outdir = tempfile.mkdtemp()
         tracker = Tracker(streaming=False, outdir=outdir, combined=True)
@@ -239,6 +239,14 @@ class TestTracker(TestCase):
         with open(os.path.join(outdir, "testresults.tap"), "r") as f:
             lines = f.readlines()
         self.assertEqual(lines[0], '1..123\n')
+
+    @mock.patch('tap.tracker.ENABLE_VERSION_13', False)
+    def test_write_plan_first_not_combined(self):
+        stream = StringIO()
+        outdir = tempfile.mkdtemp()
+        tracker = Tracker(streaming=False, outdir=outdir, combined=False)
+        with self.assertRaises(ValueError):
+            tracker.set_plan(123)
 
     @mock.patch('tap.tracker.ENABLE_VERSION_13', True)
     def test_streaming_writes_tap_version_13(self):

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -231,7 +231,6 @@ class TestTracker(TestCase):
 
     @mock.patch('tap.tracker.ENABLE_VERSION_13', False)
     def test_write_plan_first_combined(self):
-        stream = StringIO()
         outdir = tempfile.mkdtemp()
         tracker = Tracker(streaming=False, outdir=outdir, combined=True)
         tracker.set_plan(123)
@@ -242,7 +241,6 @@ class TestTracker(TestCase):
 
     @mock.patch('tap.tracker.ENABLE_VERSION_13', False)
     def test_write_plan_first_not_combined(self):
-        stream = StringIO()
         outdir = tempfile.mkdtemp()
         tracker = Tracker(streaming=False, outdir=outdir, combined=False)
         with self.assertRaises(ValueError):

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -221,6 +221,14 @@ class TestTracker(TestCase):
 
         self.assertEqual(stream.getvalue(), '1..42\n')
 
+    @mock.patch('tap.tracker.ENABLE_VERSION_13', False)
+    def test_streaming_writes_plan_first(self):
+        stream = StringIO()
+        tracker = Tracker(streaming=True, stream=stream)
+        tracker.set_plan(123)
+        tracker.generate_tap_reports()
+        self.assertEqual(stream.getvalue(), '1..123\n')
+
     @mock.patch('tap.tracker.ENABLE_VERSION_13', True)
     def test_streaming_writes_tap_version_13(self):
         stream = StringIO()

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -230,6 +230,12 @@ class TestTracker(TestCase):
         self.assertEqual(stream.getvalue(), '1..123\n')
 
     @mock.patch('tap.tracker.ENABLE_VERSION_13', False)
+    def test_write_plan_immediate_streaming(self):
+        stream = StringIO()
+        tracker = Tracker(streaming=True, stream=stream, plan=123)
+        self.assertEqual(stream.getvalue(), '1..123\n')
+
+    @mock.patch('tap.tracker.ENABLE_VERSION_13', False)
     def test_write_plan_first_combined(self):
         outdir = tempfile.mkdtemp()
         tracker = Tracker(streaming=False, outdir=outdir, combined=True)

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -222,12 +222,23 @@ class TestTracker(TestCase):
         self.assertEqual(stream.getvalue(), '1..42\n')
 
     @mock.patch('tap.tracker.ENABLE_VERSION_13', False)
-    def test_streaming_writes_plan_first(self):
+    def test_write_plan_first_streaming(self):
         stream = StringIO()
         tracker = Tracker(streaming=True, stream=stream)
         tracker.set_plan(123)
         tracker.generate_tap_reports()
         self.assertEqual(stream.getvalue(), '1..123\n')
+
+    @mock.patch('tap.tracker.ENABLE_VERSION_13', False)
+    def test_write_plan_first_file(self):
+        stream = StringIO()
+        outdir = tempfile.mkdtemp()
+        tracker = Tracker(streaming=False, outdir=outdir, combined=True)
+        tracker.set_plan(123)
+        tracker.generate_tap_reports()
+        with open(os.path.join(outdir, "testresults.tap"), "r") as f:
+            lines = f.readlines()
+        self.assertEqual(lines[0], '1..123\n')
 
     @mock.patch('tap.tracker.ENABLE_VERSION_13', True)
     def test_streaming_writes_tap_version_13(self):

--- a/tap/tracker.py
+++ b/tap/tracker.py
@@ -158,7 +158,9 @@ class Tracker(object):
                         test_case, self._test_cases[test_case], out_file)
                 if self.plan is None:
                     print(
-                        '1..{0}'.format(self.combined_line_number), file=out_file)
+                        '1..{0}'.format(self.combined_line_number),
+                        file=out_file,
+                    )
         else:
             for test_case, tap_lines in self._test_cases.items():
                 with open(self._get_tap_file_path(test_case), 'w') as out_file:

--- a/tap/tracker.py
+++ b/tap/tracker.py
@@ -181,8 +181,10 @@ class Tracker(object):
             print('TAP version 13', file=filename)
 
     def _write_plan(self, stream):
-        """
-        if we have a plan, write it to the given stream
+        """Write the plan line to the stream
+
+        If we have a plan and have not yet written it out, write it to
+        the given stream
         """
         if self.plan is not None:
             if not self._plan_written:

--- a/tap/tracker.py
+++ b/tap/tracker.py
@@ -36,7 +36,7 @@ class Tracker(object):
         # Stream output directly to a stream instead of file output.
         self.streaming = streaming
         self.stream = stream
-        # the plan is how many tests we expect (or None if we don't know yet)
+        # The total number of tests we expect (or None if we don't know yet).
         self.plan = plan
         self._plan_written = False
 
@@ -134,11 +134,9 @@ class Tracker(object):
         The results are either combined into a single output file or
         the output file name is generated from the test case.
         """
-        # this re-creates legacy behavior by writing out the plan at
-        # the end of the stream in case "set_plan" was not called up
-        # front..
+        # We're streaming but set_plan wasn't called, so we can only
+        # know the plan now (at the end)
         if self.streaming and not self._plan_written:
-            # The results already went to the stream, record the plan.
             print('1..{0}'.format(self.combined_line_number), file=self.stream)
             self._plan_written = True
             return

--- a/tap/tracker.py
+++ b/tap/tracker.py
@@ -147,11 +147,14 @@ class Tracker(object):
                 combined_file = os.path.join(self.outdir, combined_file)
             with open(combined_file, 'w') as out_file:
                 self._write_tap_version(out_file)
+                if self.plan is not None:
+                    print('1..{0}'.format(self.plan), file=out_file)
                 for test_case in self.combined_test_cases_seen:
                     self.generate_tap_report(
                         test_case, self._test_cases[test_case], out_file)
-                print(
-                    '1..{0}'.format(self.combined_line_number), file=out_file)
+                if self.plan is None:
+                    print(
+                        '1..{0}'.format(self.combined_line_number), file=out_file)
         else:
             for test_case, tap_lines in self._test_cases.items():
                 with open(self._get_tap_file_path(test_case), 'w') as out_file:

--- a/tap/tracker.py
+++ b/tap/tracker.py
@@ -127,6 +127,10 @@ class Tracker(object):
             # right here..)
             if not self.combined_test_cases_seen:
                 self._write_plan(self.stream)
+        elif not self.combined:
+            raise ValueError(
+                "set_plan can only be used with combined or streaming output"
+            )
 
     def generate_tap_reports(self):
         """Generate TAP reports.


### PR DESCRIPTION
This adds a `.set_plan()` method on `Tracker` so that streaming reporters can report how many tests they expect. If this method is NOT called, legacy behavior is preserved (the plan is written out to the stream at the end)

see https://github.com/python-tap/pytest-tap/issues/34 for context