### PR TITLE
Streaming mode should always abort from writing files.

### DIFF
--- a/tap/directive.py
+++ b/tap/directive.py
@@ -20,10 +20,10 @@ class Directive(object):
     )
 
     def __init__(self, text):
-        """Initialize the directive by parsing the text.
+        r"""Initialize the directive by parsing the text.
 
         The text is assumed to be everything after a '#\s*' on a result line.
-        """  # noqa: flake8 is grumbling about the \s in the description.
+        """
         self._text = text
         self._skip = False
         self._todo = False

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -233,11 +233,18 @@ class TestTracker(TestCase):
 
     @mock.patch("tap.tracker.ENABLE_VERSION_13", False)
     def test_write_plan_first_streaming(self):
+        outdir = tempfile.mkdtemp()
         stream = StringIO()
-        tracker = Tracker(streaming=True, stream=stream)
+        tracker = Tracker(outdir=outdir, streaming=True, stream=stream)
         tracker.set_plan(123)
+        tracker.add_ok("FakeTestCase", "YESSS!")
+
         tracker.generate_tap_reports()
-        self.assertEqual(stream.getvalue(), "1..123\n")
+
+        self.assertEqual(
+            stream.getvalue(), "1..123\n# TAP results for FakeTestCase\nok 1 YESSS!\n"
+        )
+        self.assertFalse(os.path.exists(os.path.join(outdir, "FakeTestCase.tap")))
 
     @mock.patch("tap.tracker.ENABLE_VERSION_13", False)
     def test_write_plan_immediate_streaming(self):

--- a/tap/tracker.py
+++ b/tap/tracker.py
@@ -152,11 +152,12 @@ class Tracker(object):
         The results are either combined into a single output file or
         the output file name is generated from the test case.
         """
-        # We're streaming but set_plan wasn't called, so we can only
-        # know the plan now (at the end).
-        if self.streaming and not self._plan_written:
-            print("1..{0}".format(self.combined_line_number), file=self.stream)
-            self._plan_written = True
+        if self.streaming:
+            # We're streaming but set_plan wasn't called, so we can only
+            # know the plan now (at the end).
+            if not self._plan_written:
+                print("1..{0}".format(self.combined_line_number), file=self.stream)
+                self._plan_written = True
             return
 
         if self.combined:


### PR DESCRIPTION
If the plan was set early (as is the case in pytest-tap), the streaming mode skipped the return statement in `generate_tap_reports` and was writing files when it shouldn't.

Fixes python-tap/pytest-tap#43