### PR TITLE
Remove the ability to run `python setup.py test`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,4 @@ if __name__ == "__main__":
         ],
         keywords=["TAP", "unittest"],
         cmdclass={"build_py": BuildPy, "sdist": Sdist},
-        test_suite="tap.tests",
-        tests_require=["mock"],
     )


### PR DESCRIPTION
`python setup.py test` is not the way we recommend running tests
in the contributing guides and it was broken anyway.

Fixes #85