### PR TITLE
Record that setup requires Babel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
         include_package_data=True,
         zip_safe=False,
         platforms="any",
-        setup_requires=['Babel'],
+        setup_requires=["Babel"],
         install_requires=[],
         extras_require={"yaml": ["more-itertools", "PyYAML"]},
         classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ if __name__ == "__main__":
         include_package_data=True,
         zip_safe=False,
         platforms="any",
+        setup_requires=['Babel'],
         install_requires=[],
         extras_require={"yaml": ["more-itertools", "PyYAML"]},
         classifiers=[


### PR DESCRIPTION
Babel is needed to run `python setup.py sdist` because the `compile_catalog` command must be available.

To accept your contribution, please ensure that the checklist below is complete.

* [x] Is your name/identity in the AUTHORS file?
* [x] Does the code change (if the PR contains code) have 100% test coverage?
* [x] Is CI passing all quality and testing checks?
