### PR TITLE
Let source packages also contain mo files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ matrix:
       python: 3.7
       env: TOX_ENV=coverage
 install:
-  - pip3 install Babel tox
+  - pip3 install tox
 script: tox -e $TOX_ENV

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ class ReleaseCommand(Command):
         self.run_command("sdist")
         self.run_command("bdist_wheel")
 
-        
+
 # The docs import setup.py for the version so only call setup when not behaving
 # as a module.
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -9,31 +9,35 @@ Developer documentation is on
 `Read the Docs <https://tappy.readthedocs.io/>`_.
 """
 
-from setuptools import find_packages, setup
-from setuptools.command.build_py import build_py
-from setuptools.command.sdist import sdist
+from setuptools import find_packages, setup, Command
 
 import tap
 
 
-class BuildPy(build_py):
-    """Custom ``build_py`` command to always build mo files for wheels."""
+class ReleaseCommand(Command):
+    description = "generate distribution release artifacts"
+    user_options = []
+
+    def initialize_options(self):
+        """Initialize options.
+        This method overrides a required abstract method.
+        """
+
+    def finalize_options(self):
+        """Finalize options.
+        This method overrides a required abstract method.
+        """
 
     def run(self):
+        """Generate the distribution release artifacts.
+        The custom command is used to ensure that compiling
+        po to mo is not skipped.
+        """
         self.run_command("compile_catalog")
-        # build_py is an old style class so super cannot be used.
-        build_py.run(self)
+        self.run_command("sdist")
+        self.run_command("bdist_wheel")
 
-
-class Sdist(sdist):
-    """Custom ``sdist`` command to ensure that mo files are always created."""
-
-    def run(self):
-        self.run_command("compile_catalog")
-        # sdist is an old style class so super cannot be used.
-        sdist.run(self)
-
-
+        
 # The docs import setup.py for the version so only call setup when not behaving
 # as a module.
 if __name__ == "__main__":
@@ -73,5 +77,5 @@ if __name__ == "__main__":
             "Topic :: Software Development :: Testing",
         ],
         keywords=["TAP", "unittest"],
-        cmdclass={"build_py": BuildPy, "sdist": Sdist},
+        cmdclass={"release": ReleaseCommand},
     )

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ envlist =
 
 [testenv]
 deps =
-    Babel
     mock
     pytest
 commands = pytest {envsitepackagesdir}/tap
@@ -18,14 +17,12 @@ commands = pytest {envsitepackagesdir}/tap
 [testenv:windows]
 basepython = python3.6
 deps =
-    Babel
     mock
     pytest
 commands = pytest
 
 [testenv:with_optional]
 deps =
-    Babel
     mock
     pyyaml
     more-itertools
@@ -33,13 +30,11 @@ commands = python tap/tests/run.py
 
 [testenv:runner]
 deps =
-    Babel
     mock
 commands = python tap/tests/run.py
 
 [testenv:lint]
 deps =
-    Babel
     black
     flake8
 commands =
@@ -48,7 +43,6 @@ commands =
 
 [testenv:integration]
 deps =
-    Babel
     mock
     pytest
     pytest-tap
@@ -61,7 +55,6 @@ setenv =
     CI = true
 passenv = TRAVIS*
 deps =
-    Babel
     coverage
     mock
     codecov


### PR DESCRIPTION
This removes the dependency on Babel for source-based package installation. This was suggested as a better version of #96. Code was simply copied from https://github.com/python-tap/pytest-tap/blob/master/setup.py

With this PR, I can successfully do:

```bash
$ python3 -m venv .venv
$ source .venv/bin/activate
$ pip install Babel wheel
$ python3 setup.py release
$ pip uninstall Babel wheel
$ pip install dist/tap.py-3.0.tar.gz 
```

To accept your contribution, please ensure that the checklist below is complete.

* [x] Is your name/identity in the AUTHORS file?
* [x] Does the code change (if the PR contains code) have 100% test coverage?
* [x] Is CI passing all quality and testing checks?
