### PR TITLE
test_tracker.py: Fix test failure in non-English locales

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Contributors
 * Nicolas Caniart
 * Richard Bosworth
 * Ross Burton
+* Simon McVittie

--- a/tap/tests/test_tracker.py
+++ b/tap/tests/test_tracker.py
@@ -234,7 +234,10 @@ class TestTracker(TestCase):
         tracker.generate_tap_reports()
 
         self.assertEqual(
-            stream.getvalue(), "1..123\n# TAP results for FakeTestCase\nok 1 YESSS!\n"
+            stream.getvalue(),
+            "1..123\n{header}\nok 1 YESSS!\n".format(
+                header=self._make_header("FakeTestCase")
+            ),
         )
         self.assertFalse(os.path.exists(os.path.join(outdir, "FakeTestCase.tap")))
 


### PR DESCRIPTION
The header is only "# TAP results for FakeTestCase" if we are running
in an English locale, or in a locale not otherwise supported by tappy.
For example, test failure can be reproduced with:

    $ LANGUAGE=fr_FR.utf8 pytest-3 build/lib