### PR TITLE
Add latest Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
       python: 3.7
       env: TOX_ENV=py37
     - os: linux
+      python: 3.8
+      env: TOX_ENV=py38
+    - os: linux
       python: pypy3.5
       env: TOX_ENV=pypy3
     - os: osx
@@ -20,22 +23,22 @@ matrix:
       language: generic
       env: TOX_ENV=py37
     - os: linux
-      python: 3.6
+      python: 3.8
       env: TOX_ENV=with_optional
     - os: linux
-      python: 3.7
+      python: 3.8
       env: TOX_ENV=runner
     - os: linux
-      python: 3.7
+      python: 3.8
       env: TOX_ENV=module
     - os: linux
-      python: 3.7
+      python: 3.8
       env: TOX_ENV=lint
     - os: linux
-      python: 3.7
+      python: 3.8
       env: TOX_ENV=integration
     - os: linux
-      python: 3.7
+      python: 3.8
       env: TOX_ENV=coverage
 install:
   - pip3 install tox

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ on Python
 3.5,
 3.6,
 3.7,
+3.8,
 and PyPy.
 It is continuously tested on Linux, OS X, and Windows.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Python
 3.5,
 3.6,
 3.7,
+3.8,
 and PyPy.
 It is continuously tested on Linux, OS X, and Windows.
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,11 @@
 Releases
 ========
 
+Version 3.1, To Be Released
+---------------------------
+
+* Add support for Python 3.8.
+
 Version 3.0, Released January 10, 2020
 --------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: Implementation :: PyPy",
             "Topic :: Software Development :: Testing",
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist =
     py35
     py36
+    py37
+    py38
     pypy3
     runner
     module


### PR DESCRIPTION
Adds Python 3.8 as a supported version in package metadata and includes this version in CI tests.

To accept your contribution, please ensure that the checklist below is complete.

* [x] Is your name/identity in the AUTHORS file?
* [x] Does the code change (if the PR contains code) have 100% test coverage?
* [x] Is CI passing all quality and testing checks?
