### PR TITLE
Fix packaging after switching to hatchling

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include AUTHORS
-include LICENSE
-include README.md
-recursive-include docs *
-prune docs/_build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ include = ["src/*", "docs/releases.rst", "LICENSE"]
 sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
-include = ["src/*", "docs/releases.rst", "LICENSE"]
+include = ["src/*", "LICENSE"]
 sources = ["src"]
 packages = ["tap"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,6 @@ include = [
 sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
-include = [
-    "/src",
-]
 sources = ["src"]
 packages = ["tap"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tap.py"
-version = "3.2"
+version = "3.2.1"
 description = "Test Anything Protocol (TAP) tools"
 readme = "docs/releases.rst"
 license = {text = "BSD"}
@@ -55,6 +55,7 @@ sources = ["src"]
 [tool.hatch.build.targets.wheel]
 include = ["src/*", "docs/releases.rst", "LICENSE"]
 sources = ["src"]
+packages = ["tap"]
 
 [tool.pytest.ini_options]
 pythonpath = [".", "src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,17 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-include = ["src/*"]
+include = [
+    "/src",
+    "/docs",
+    "/tests",
+]
 sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
-include = ["src/*"]
+include = [
+    "/src",
+]
 sources = ["src"]
 packages = ["tap"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,11 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-include = ["src/*", "docs/releases.rst", "LICENSE"]
+include = ["src/*"]
 sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
-include = ["src/*", "LICENSE"]
+include = ["src/*"]
 sources = ["src"]
 packages = ["tap"]
 

--- a/src/tap/__init__.py
+++ b/src/tap/__init__.py
@@ -1,4 +1,4 @@
 from .runner import TAPTestRunner
 
 __all__ = ["TAPTestRunner"]
-__version__ = "3.2"
+__version__ = "3.2.1"

--- a/tox.ini
+++ b/tox.ini
@@ -8,16 +8,13 @@ deps =
     pyyaml
     more-itertools
 commands = python tests/run.py
-package = editable
 
 [testenv:runner]
 commands = python tests/run.py
-package = editable
 
 [testenv:module]
 commands = python -m tap
 changedir = src
-package = editable
 
 [testenv:integration]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -24,9 +24,8 @@ deps =
     pytest
     pytest-tap
 commands =
-    pytest --tap-files --tap-outdir=results src/tap
+    pytest --tap-files --tap-outdir=results {envsitepackagesdir}/tap
     tappy results
-package = editable
 
 [testenv:coverage]
 setenv =

--- a/uv.lock
+++ b/uv.lock
@@ -668,7 +668,7 @@ wheels = [
 
 [[package]]
 name = "tap-py"
-version = "3.2"
+version = "3.2.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
I messed up a bunch of things when I switched the packaging to hatchling. This branch corrects the issues.

Fixes #150, #151, #152 

```
unzip tap_py-3.2.1-py3-none-any.whl
Archive:  tap_py-3.2.1-py3-none-any.whl
  inflating: tap/__init__.py         
  inflating: tap/__main__.py         
  inflating: tap/adapter.py          
  inflating: tap/directive.py        
  inflating: tap/formatter.py        
  inflating: tap/line.py             
  inflating: tap/loader.py           
  inflating: tap/main.py             
  inflating: tap/parser.py           
  inflating: tap/rules.py            
  inflating: tap/runner.py           
  inflating: tap/tracker.py          
  inflating: tap/tests/__init__.py   
  inflating: tap/tests/factory.py    
  inflating: tap/tests/test_example.py  
  inflating: tap/tests/testcase.py   
  inflating: tap_py-3.2.1.dist-info/METADATA  
  inflating: tap_py-3.2.1.dist-info/WHEEL  
  inflating: tap_py-3.2.1.dist-info/entry_points.txt  
  inflating: tap_py-3.2.1.dist-info/licenses/AUTHORS  
  inflating: tap_py-3.2.1.dist-info/licenses/LICENSE  
  inflating: tap_py-3.2.1.dist-info/RECORD  
```