### PR TITLE
Support raw yaml block in tracker

### DIFF
--- a/src/tap/line.py
+++ b/src/tap/line.py
@@ -113,11 +113,10 @@ class Result(Line):
             diagnostics = "\n" + self.diagnostics.rstrip()
         yaml_block = ""
         if self._yaml_block is not None:
-            indent = " "
             indented_yaml_block = "\n".join(
-                f"{indent}{line}" for line in self._yaml_block.splitlines()
+                f" {line}" for line in self._yaml_block.splitlines()
             )
-            yaml_block = f"\n{indent}---\n{indented_yaml_block}\n{indent}..."
+            yaml_block = f"\n ---\n{indented_yaml_block}\n ..."
         return (
             f"{is_not}ok {self.number} {self.description}{directive}"
             f"{diagnostics}{yaml_block}"

--- a/src/tap/line.py
+++ b/src/tap/line.py
@@ -114,7 +114,9 @@ class Result(Line):
         yaml_block = ""
         if self._yaml_block is not None:
             indent = " "
-            indented_yaml_block = '\n'.join(f"{indent}{line}" for line in self._yaml_block.splitlines())
+            indented_yaml_block = "\n".join(
+                f"{indent}{line}" for line in self._yaml_block.splitlines()
+            )
             yaml_block = f"\n{indent}---\n{indented_yaml_block}\n{indent}..."
         return f"{is_not}ok {self.number} {self.description}{directive}{diagnostics}{yaml_block}"
 

--- a/src/tap/line.py
+++ b/src/tap/line.py
@@ -111,7 +111,12 @@ class Result(Line):
         diagnostics = ""
         if self.diagnostics is not None:
             diagnostics = "\n" + self.diagnostics.rstrip()
-        return f"{is_not}ok {self.number} {self.description}{directive}{diagnostics}"
+        yaml_block = ""
+        if self._yaml_block is not None:
+            indent = " "
+            indented_yaml_block = '\n'.join(f"{indent}{line}" for line in self._yaml_block.splitlines())
+            yaml_block = f"\n{indent}---\n{indented_yaml_block}\n{indent}..."
+        return f"{is_not}ok {self.number} {self.description}{directive}{diagnostics}{yaml_block}"
 
 
 class Plan(Line):

--- a/src/tap/line.py
+++ b/src/tap/line.py
@@ -118,7 +118,8 @@ class Result(Line):
                 f"{indent}{line}" for line in self._yaml_block.splitlines()
             )
             yaml_block = f"\n{indent}---\n{indented_yaml_block}\n{indent}..."
-        return f"{is_not}ok {self.number} {self.description}{directive}{diagnostics}{yaml_block}"
+        return (f"{is_not}ok {self.number} {self.description}{directive}"
+                f"{diagnostics}{yaml_block}")
 
 
 class Plan(Line):

--- a/src/tap/line.py
+++ b/src/tap/line.py
@@ -118,8 +118,10 @@ class Result(Line):
                 f"{indent}{line}" for line in self._yaml_block.splitlines()
             )
             yaml_block = f"\n{indent}---\n{indented_yaml_block}\n{indent}..."
-        return (f"{is_not}ok {self.number} {self.description}{directive}"
-                f"{diagnostics}{yaml_block}")
+        return (
+            f"{is_not}ok {self.number} {self.description}{directive}"
+            f"{diagnostics}{yaml_block}"
+        )
 
 
 class Plan(Line):

--- a/src/tap/tracker.py
+++ b/src/tap/tracker.py
@@ -73,23 +73,25 @@ class Tracker:
             if self.combined:
                 self.combined_test_cases_seen.append(class_name)
 
-    def add_ok(self, class_name, description, directive="", diagnostics=None):
+    def add_ok(self, class_name, description, directive="", diagnostics=None, raw_yaml_block=None):
         result = Result(
             ok=True,
             number=self._get_next_line_number(class_name),
             description=description,
             diagnostics=diagnostics,
             directive=Directive(directive),
+            raw_yaml_block=raw_yaml_block,
         )
         self._add_line(class_name, result)
 
-    def add_not_ok(self, class_name, description, directive="", diagnostics=None):
+    def add_not_ok(self, class_name, description, directive="", diagnostics=None, raw_yaml_block=None):
         result = Result(
             ok=False,
             number=self._get_next_line_number(class_name),
             description=description,
             diagnostics=diagnostics,
             directive=Directive(directive),
+            raw_yaml_block=raw_yaml_block
         )
         self._add_line(class_name, result)
 

--- a/src/tap/tracker.py
+++ b/src/tap/tracker.py
@@ -73,7 +73,14 @@ class Tracker:
             if self.combined:
                 self.combined_test_cases_seen.append(class_name)
 
-    def add_ok(self, class_name, description, directive="", diagnostics=None, raw_yaml_block=None):
+    def add_ok(
+        self,
+        class_name,
+        description,
+        directive="",
+        diagnostics=None,
+        raw_yaml_block=None,
+    ):
         result = Result(
             ok=True,
             number=self._get_next_line_number(class_name),
@@ -84,14 +91,21 @@ class Tracker:
         )
         self._add_line(class_name, result)
 
-    def add_not_ok(self, class_name, description, directive="", diagnostics=None, raw_yaml_block=None):
+    def add_not_ok(
+        self,
+        class_name,
+        description,
+        directive="",
+        diagnostics=None,
+        raw_yaml_block=None,
+    ):
         result = Result(
             ok=False,
             number=self._get_next_line_number(class_name),
             description=description,
             diagnostics=diagnostics,
             directive=Directive(directive),
-            raw_yaml_block=raw_yaml_block
+            raw_yaml_block=raw_yaml_block,
         )
         self._add_line(class_name, result)
 

--- a/src/tap/tracker.py
+++ b/src/tap/tracker.py
@@ -73,14 +73,7 @@ class Tracker:
             if self.combined:
                 self.combined_test_cases_seen.append(class_name)
 
-    def add_ok(
-        self,
-        class_name,
-        description,
-        directive="",
-        diagnostics=None,
-        raw_yaml_block=None,
-    ):
+    def add_ok(self, class_name, description, directive="", diagnostics=None, raw_yaml_block=None):
         result = Result(
             ok=True,
             number=self._get_next_line_number(class_name),
@@ -91,21 +84,14 @@ class Tracker:
         )
         self._add_line(class_name, result)
 
-    def add_not_ok(
-        self,
-        class_name,
-        description,
-        directive="",
-        diagnostics=None,
-        raw_yaml_block=None,
-    ):
+    def add_not_ok(self, class_name, description, directive="", diagnostics=None, raw_yaml_block=None):
         result = Result(
             ok=False,
             number=self._get_next_line_number(class_name),
             description=description,
             diagnostics=diagnostics,
             directive=Directive(directive),
-            raw_yaml_block=raw_yaml_block,
+            raw_yaml_block=raw_yaml_block
         )
         self._add_line(class_name, result)
 

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -46,6 +46,5 @@ class TestResult(unittest.TestCase):
 message: test_message
 severity: fail
 """
-        result = Result(False, 46, "passing", None, None,
-                        raw_yaml_block=raw_yaml_block)
+        result = Result(False, 46, "passing", None, None, raw_yaml_block=raw_yaml_block)
         self.assertEqual(result.yaml_block["message"], "test_message")

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -38,5 +38,14 @@ class TestResult(unittest.TestCase):
         self.assertEqual("ok 44 passing # SKIP a reason", str(result))
 
     def test_str_diagnostics(self):
-        result = Result(False, 43, "failing", diagnostics="# more info")
-        self.assertEqual("not ok 43 failing\n# more info", str(result))
+        result = Result(False, 45, "failing", diagnostics="# more info")
+        self.assertEqual("not ok 45 failing\n# more info", str(result))
+
+    def test_yaml_block(self):
+        raw_yaml_block = """\
+message: test_message
+severity: fail
+"""
+        result = Result(False, 46, "passing", None, None,
+                        raw_yaml_block=raw_yaml_block)
+        self.assertEqual(result.yaml_block["message"], "test_message")

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -3,6 +3,14 @@ import unittest
 from tap.directive import Directive
 from tap.line import Line, Result
 
+try:
+    import yaml
+    from more_itertools import peekable  # noqa
+
+    have_yaml = True
+except ImportError:
+    have_yaml = False
+
 
 class TestLine(unittest.TestCase):
     """Tests for tap.line.Line"""
@@ -41,11 +49,13 @@ class TestResult(unittest.TestCase):
         result = Result(False, 45, "failing", diagnostics="# more info")
         self.assertEqual("not ok 45 failing\n# more info", str(result))
 
-    @unittest.mock.patch("tap.line.LOAD_YAML", True)
     def test_yaml_block(self):
         raw_yaml_block = """\
 message: test_message
 severity: fail
 """
         result = Result(False, 46, "passing", None, None, raw_yaml_block=raw_yaml_block)
-        self.assertEqual(result.yaml_block["message"], "test_message")
+        if have_yaml:
+            self.assertEqual(result.yaml_block["message"], "test_message")
+        else:
+            self.assertIsNone(result.yaml_block)

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -41,6 +41,7 @@ class TestResult(unittest.TestCase):
         result = Result(False, 45, "failing", diagnostics="# more info")
         self.assertEqual("not ok 45 failing\n# more info", str(result))
 
+    @unittest.mock.patch("tap.line.LOAD_YAML", True)
     def test_yaml_block(self):
         raw_yaml_block = """\
 message: test_message

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -54,8 +54,9 @@ class TestResult(unittest.TestCase):
 message: test_message
 severity: fail
 """
-        result = Result(False, 46, "passing", None, None, raw_yaml_block=raw_yaml_block)
+        result = Result(False, 46, "passing", raw_yaml_block=raw_yaml_block)
         if have_yaml:
             self.assertEqual(result.yaml_block["message"], "test_message")
+            self.assertIn(str(result), " ---\n message: test_message\n severity: fail\n ...")
         else:
             self.assertIsNone(result.yaml_block)

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -4,7 +4,7 @@ from tap.directive import Directive
 from tap.line import Line, Result
 
 try:
-    import yaml
+    import yaml  # noqa
     from more_itertools import peekable  # noqa
 
     have_yaml = True
@@ -57,6 +57,6 @@ severity: fail
         result = Result(False, 46, "passing", raw_yaml_block=raw_yaml_block)
         if have_yaml:
             self.assertEqual(result.yaml_block["message"], "test_message")
-            self.assertIn(str(result), " ---\n message: test_message\n severity: fail\n ...")
+            self.assertIn(" ---\n message: test_message\n severity: fail\n ...", str(result))
         else:
             self.assertIsNone(result.yaml_block)

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -58,7 +58,7 @@ severity: fail
         if have_yaml:
             self.assertEqual(result.yaml_block["message"], "test_message")
             self.assertIn(
-                str(result), " ---\n message: test_message\n severity: fail\n ..."
+                " ---\n message: test_message\n severity: fail\n ...", str(result)
             )
         else:
             self.assertIsNone(result.yaml_block)

--- a/tests/test_line.py
+++ b/tests/test_line.py
@@ -57,6 +57,8 @@ severity: fail
         result = Result(False, 46, "passing", raw_yaml_block=raw_yaml_block)
         if have_yaml:
             self.assertEqual(result.yaml_block["message"], "test_message")
-            self.assertIn(str(result), " ---\n message: test_message\n severity: fail\n ...")
+            self.assertIn(
+                str(result), " ---\n message: test_message\n severity: fail\n ..."
+            )
         else:
             self.assertIsNone(result.yaml_block)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -295,6 +295,24 @@ class TestTracker(TestCase):
         line = tracker._test_cases["FakeTestCase"][0]
         self.assertEqual("# more info\n", line.diagnostics)
 
+    def test_adds_ok_with_yaml_block(self):
+        tracker = Tracker()
+        tracker.add_ok("FakeTestCase", "a description", raw_yaml_block="""\
+message: test_message
+severity: pass
+""")
+        line = tracker._test_cases["FakeTestCase"][0]
+        self.assertEqual("test_message", line.yaml_block["message"])
+
+    def test_adds_not_ok_with_yaml_block(self):
+        tracker = Tracker()
+        tracker.add_not_ok("FakeTestCase", "a description", raw_yaml_block="""\
+message: test_message
+severity: fail
+""")
+        line = tracker._test_cases["FakeTestCase"][0]
+        self.assertEqual("test_message", line.yaml_block["message"])
+
     def test_header_displayed_by_default(self):
         tracker = Tracker()
         self.assertTrue(tracker.header)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -297,19 +297,27 @@ class TestTracker(TestCase):
 
     def test_adds_ok_with_yaml_block(self):
         tracker = Tracker()
-        tracker.add_ok("FakeTestCase", "a description", raw_yaml_block="""\
+        tracker.add_ok(
+            "FakeTestCase",
+            "a description",
+            raw_yaml_block="""\
 message: test_message
 severity: pass
-""")
+""",
+        )
         line = tracker._test_cases["FakeTestCase"][0]
         self.assertEqual("test_message", line.yaml_block["message"])
 
     def test_adds_not_ok_with_yaml_block(self):
         tracker = Tracker()
-        tracker.add_not_ok("FakeTestCase", "a description", raw_yaml_block="""\
+        tracker.add_not_ok(
+            "FakeTestCase",
+            "a description",
+            raw_yaml_block="""\
 message: test_message
 severity: fail
-""")
+""",
+        )
         line = tracker._test_cases["FakeTestCase"][0]
         self.assertEqual("test_message", line.yaml_block["message"])
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -8,7 +8,7 @@ from tap.tests import TestCase
 from tap.tracker import Tracker
 
 try:
-    import yaml
+    import yaml  # noqa
     from more_itertools import peekable  # noqa
 
     have_yaml = True

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -295,6 +295,8 @@ class TestTracker(TestCase):
         line = tracker._test_cases["FakeTestCase"][0]
         self.assertEqual("# more info\n", line.diagnostics)
 
+    @mock.patch("tap.tracker.ENABLE_VERSION_13", True)
+    @mock.patch("tap.line.LOAD_YAML", True)
     def test_adds_ok_with_yaml_block(self):
         tracker = Tracker()
         tracker.add_ok("FakeTestCase", "a description", raw_yaml_block="""\
@@ -304,6 +306,8 @@ severity: pass
         line = tracker._test_cases["FakeTestCase"][0]
         self.assertEqual("test_message", line.yaml_block["message"])
 
+    @mock.patch("tap.tracker.ENABLE_VERSION_13", True)
+    @mock.patch("tap.line.LOAD_YAML", True)
     def test_adds_not_ok_with_yaml_block(self):
         tracker = Tracker()
         tracker.add_not_ok("FakeTestCase", "a description", raw_yaml_block="""\

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -7,6 +7,14 @@ from unittest import mock
 from tap.tests import TestCase
 from tap.tracker import Tracker
 
+try:
+    import yaml
+    from more_itertools import peekable  # noqa
+
+    have_yaml = True
+except ImportError:
+    have_yaml = False
+
 
 class TestTracker(TestCase):
     def _make_header(self, test_case):
@@ -295,8 +303,6 @@ class TestTracker(TestCase):
         line = tracker._test_cases["FakeTestCase"][0]
         self.assertEqual("# more info\n", line.diagnostics)
 
-    @mock.patch("tap.tracker.ENABLE_VERSION_13", True)
-    @mock.patch("tap.line.LOAD_YAML", True)
     def test_adds_ok_with_yaml_block(self):
         tracker = Tracker()
         tracker.add_ok(
@@ -308,10 +314,11 @@ severity: pass
 """,
         )
         line = tracker._test_cases["FakeTestCase"][0]
-        self.assertEqual("test_message", line.yaml_block["message"])
+        if have_yaml:
+            self.assertEqual("test_message", line.yaml_block["message"])
+        else:
+            self.assertIsNone(line.yaml_block)
 
-    @mock.patch("tap.tracker.ENABLE_VERSION_13", True)
-    @mock.patch("tap.line.LOAD_YAML", True)
     def test_adds_not_ok_with_yaml_block(self):
         tracker = Tracker()
         tracker.add_not_ok(
@@ -323,7 +330,10 @@ severity: fail
 """,
         )
         line = tracker._test_cases["FakeTestCase"][0]
-        self.assertEqual("test_message", line.yaml_block["message"])
+        if have_yaml:
+            self.assertEqual("test_message", line.yaml_block["message"])
+        else:
+            self.assertIsNone(line.yaml_block)
 
     def test_header_displayed_by_default(self):
         tracker = Tracker()


### PR DESCRIPTION
Improve support for YAML blocks:
- Allowing passing raw_yaml_block to tracker when adding test result
- Output YAML block in generated TAP file

* [x] Is your name/identity in the AUTHORS file?
* [x] Does the code change (if the PR contains code) have 100% test coverage?
* [x] Is CI passing all quality and testing checks?
