### PR TITLE
Revert "Add latest Python versions (#109)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Installation
 tappy is available for download from [PyPI][pypi]. tappy is currently supported
 on Python
 3.7,
-3.8,
 3.9,
 3.10,
 and PyPy.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,6 @@ tappy is available for download from `PyPI
 <https://pypi.python.org/pypi/tap.py>`_. tappy is currently supported on
 Python
 3.7,
-3.8,
 3.9,
 3.10,
 and PyPy.

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -25,11 +25,9 @@ Version 3.1, Released December 29, 2021
 
 * Add support for Python 3.10.
 * Add support for Python 3.9.
-* Add support for Python 3.8.
 * Drop support for Python 3.5 (it is end-of-life).
 * Fix parsing of multi-line strings in YAML blocks (#111)
 * Remove unmaintained i18n support.
-
 Version 3.0, Released January 10, 2020
 --------------------------------------
 


### PR DESCRIPTION
## Summary
- revert the surviving `python-tap/tappy#109` changes that still exist on current `main`
- remove the Python 3.8 support lines in the README and docs that still blame back to `#109`
- leave the modern build/config stack alone instead of trying to resurrect deleted `.travis.yml` or `setup.py`

## Notes
- this was a conflict-heavy revert because `#109` was merged into `master` in 2020 and the repo has changed substantially since then
- the resulting revert commit is intentionally small and only touches the three lines that still descend from `#109`

## Testing
- not run locally (`pytest` is not installed in this environment)